### PR TITLE
Add elasticsearch template parameters

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.0.2
+version: 11.1.0
 appVersion: 3.1.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -84,6 +84,10 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.ilm.policy`                           | Elasticsearch ILM policy to create                                             | `{}`                                               |
 | `elasticsearch.ilm.policies`                         | Elasticsearch ILM policies to create, map of policy IDs and policies           | `{}`                                               |
 | `elasticsearch.ilm.policy_overwrite`                 | Elastichsarch ILM policy overwrite                                             | `false`                                            |
+| `elasticsearch.template.enabled`                     | Elastichsarch Index Template enabled                                           | `false`                                            |
+| `elasticsearch.template.name`                        | Elastichsarch Index Template Name                                              | `fluentd-template`                                 |
+| `elasticsearch.template.file`                        | Elasticsearch Index Template File Name (inside the daemonset)                  | `fluentd-template.json`                            |
+| `elasticsearch.template.content`                     | Elasticsearch Index Template Content                                           | _see `values.yaml`_                                |
 | `elasticsearch.indexName`                            | Elasticsearch Index Name                                                       | `fluentd`                                          |
 | `elasticsearch.path`                                 | Elasticsearch Path                                                             | `""`                                               |
 | `elasticsearch.scheme`                               | Elasticsearch scheme setting                                                   | `http`                                             |

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -522,6 +522,10 @@ data:
       ilm_policies "#{ENV['ILM_POLICIES']}"
       ilm_policy_overwrite "#{ENV['ILM_POLICY_OVERWRITE']}"
 {{- end }}
+{{- if or .Values.elasticsearch.template.enabled .Values.elasticsearch.ilm.enabled }}
+      template_name "#{ENV['TEMPLATE_NAME']}"
+      template_file "#{ENV['TEMPLATE_FILE']}"
+{{- end }}
       log_es_400_reason "#{ENV['OUTPUT_LOG_400_REASON']}"
       reconnect_on_error "#{ENV['OUTPUT_RECONNECT_ON_ERROR']}"
       reload_on_failure "#{ENV['OUTPUT_RELOAD_ON_FAILURE']}"
@@ -547,6 +551,11 @@ data:
 {{- end }}
     </match>
     </label>
+{{- end }}
+
+{{- if or .Values.elasticsearch.template.enabled .Values.elasticsearch.ilm.enabled }}
+  {{ .Values.elasticsearch.template.file }}: |-
+{{ .Values.elasticsearch.template.content | indent 4 }}
 {{- end }}
 
 {{- range $key, $value := .Values.extraConfigMaps }}

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -82,6 +82,12 @@ spec:
         - name: ILM_POLICY_OVERWRITE
           value: {{ .Values.elasticsearch.ilm.policy_overwrite | quote }}
 {{- end }}
+{{- if or .Values.elasticsearch.template.enabled .Values.elasticsearch.ilm.enabled }}
+        - name: TEMPLATE_NAME
+          value: {{ .Values.elasticsearch.template.name | quote }}
+        - name: TEMPLATE_FILE
+          value: "/etc/fluent/config.d/{{ .Values.elasticsearch.template.file }}"
+{{- end }}
         - name: OUTPUT_SCHEME
           {{- if .Values.awsSigningSidecar.enabled }}
           value: 'http'

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -93,6 +93,22 @@ elasticsearch:
       # ilm_policy_id1: {}
       # ilm_policy_id2: {}
     policy_overwrite: false
+  template:
+    enabled: false
+    name: fluentd-template
+    file: fluentd-template.json
+    content: |-
+      {
+        "index_patterns": [
+            "logstash-*"
+        ],
+        "settings": {
+            "index": {
+                "number_of_replicas": "1"
+            }
+        }
+      }
+
   path: ""
   scheme: "http"
   sslVerify: true


### PR DESCRIPTION
To fix ILM policy creation logic.

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/{{ .GitHubOrg }}/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
# Which chart
fluentd-elasticsearch

# What this PR does / why we need it
It actually makes the ILM features of the elasticsearch plugin usable in this chart.

# Which issue this PR fixes
* fixes #17 
* relates to https://github.com/kiwigrid/helm-charts/issues/396

# Special notes for your reviewer
* With these changes an index template and an ILM policy are created and the indices are attached even with logstash enabled.
* I did not try this without logstash enabled.
* Since these template parameters should always be supplied if ILM is enabled, I use this condition.
* But the index template could also be used without ILM so this is possible too.
* I am not sure if the parameter `elasticsearch.template.file` should even be modifiable through `values.yaml` as that's really just the name of the file _inside_ the daemonset pod.
* This should probably be documented better than just in this simple table in the README. I could add a section below that.

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] All variables are documented in the charts README

pinging owner according to guidelines :slightly_smiling_face: @monotek 