### PR TITLE
introduced variable fluentConfDir in order to configure conf location

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.1.0
+version: 11.1.1
 appVersion: 3.1.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.1.1
+version: 11.2.0
 appVersion: 3.1.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -119,6 +119,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `secret`                                             | List of env vars that are set from secrets and added to the fluentd pods       | `[]`                                               |
 | `extraVolumeMounts`                                  | Mount extra volume, required to mount ssl certificates when ES has tls enabled | `[]`                                               |
 | `extraVolume`                                        | Extra volume                                                                   | `[]`                                               |
+| `fluentConfDir`                                      | Specify where to mount fluentd location                                        | `/etc/fluent/config.d`                                         |
 | `hostLogDir.varLog`                                  | Specify where fluentd can find var log                                         | `/var/log`                                         |
 | `hostLogDir.dockerContainers`                        | Specify where fluentd can find logs for docker container                       | `/var/lib/docker/containers`                       |
 | `hostLogDir.libSystemdDir`                           | Specify where fluentd can find logs for lib Systemd                            | `/usr/lib64`                                       |

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -174,7 +174,7 @@ spec:
           mountPath: {{ .Values.hostLogDir.libSystemdDir }}
           readOnly: true
         - name: config-volume
-          mountPath: /etc/fluent/config.d
+          mountPath: {{ .Values.fluentConfDir }}
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -38,6 +38,8 @@ awsSigningSidecar:
 # Pods to make scheduling of the pending Pod possible.
 priorityClassName: ""
 
+fluentConfDir: "/etc/fluent/config.d"
+
 # Specify where fluentd can find logs
 hostLogDir:
   varLog: /var/log


### PR DESCRIPTION
# Which chart

Fluentd-elasticsearch

# What this PR does / why we need it

add variable in order to configure fluent conf location


# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X ] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X ] Chart Version bumped
- [X ] All variables are documented in the charts README