### PR TITLE
Keep container log timestamps

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.2.1
+version: 11.3.0
 appVersion: 3.1.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.2.0
+version: 11.2.1
 appVersion: 3.1.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -57,6 +57,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `podAnnotations`                                     | Optional daemonset's pods annotations                                          | `NULL`                                             |
 | `configMaps.useDefaults.systemConf`                  | Use default system.conf                                                        | `true`                                             |
 | `configMaps.useDefaults.containersInputConf`         | Use default containers.input.conf                                              | `true`                                             |
+| `configMaps.useDefaults.containersKeepTimeKey`       | Keep the container log timestamp as part of the log data.                      | `false`                                            |
 | `configMaps.useDefaults.systemInputConf`             | Use default system.input.conf                                                  | `true`                                             |
 | `configMaps.useDefaults.forwardInputConf`            | Use default forward.input.conf                                                 | `true`                                             |
 | `configMaps.useDefaults.monitoringConf`              | Use default monitoring.conf                                                    | `true`                                             |

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -125,10 +125,16 @@ data:
           format json
           time_key time
           time_format %Y-%m-%dT%H:%M:%S.%NZ
+{{- if .Values.configMaps.useDefaults.containersKeepTimeKey }}
+          keep_time_key true
+{{- end }}          
         </pattern>
         <pattern>
           format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
           time_format %Y-%m-%dT%H:%M:%S.%N%:z
+{{- if .Values.configMaps.useDefaults.containersKeepTimeKey }}
+          keep_time_key true
+{{- end }}          
         </pattern>
       </parse>
     </source>

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -282,6 +282,9 @@ configMaps:
   useDefaults:
     systemConf: true
     containersInputConf: true
+    ## Set containersKeepTimeKey to true to keep the kubernetes container log timestamp as part of the log message
+    ## Read keep_time_key at https://docs.fluentd.org/configuration/parse-section
+    containersKeepTimeKey: false
     systemInputConf: true
     forwardInputConf: true
     monitoringConf: true


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/{{ .GitHubOrg }}/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
# Which chart
fluentd-elasticsearch

# What this PR does / why we need it
Allows keeping the timestamp of the container log as part of the log information so Elasticsearch gets a timestamp field.

# Which issue this PR fixes
Discussed at: https://github.com/kokuwaio/helm-charts/issues/28

# Special notes for your reviewer
Discussed at: https://github.com/kokuwaio/helm-charts/issues/28

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ X ] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ X ] Chart Version bumped
- [ X ] All variables are documented in the charts README