### PR TITLE
Add include_timestamp parameter

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.5.0
+version: 11.6.0
 appVersion: 3.1.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -104,6 +104,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.reloadConnections`                    | Elasticsearch reload connections                                               | `false`                                            |
 | `elasticsearch.requestTimeout`                       | Elasticsearch request timeout                                                  | `5s`                                               |
 | `elasticsearch.suppressTypeName`                     | Elasticsearch type name suppression (for ES >= 7)                              | `false`                                            |
+| `elasticsearch.includeTimestamp`                     | Elasticsearch Include timestamp (param used only if logstash is disabled)      | `false`                                            |
 | `elasticsearch.buffer.enabled`                       | Elasticsearch Buffer enabled                                                   | `true`                                             |
 | `elasticsearch.buffer.chunkKeys`                     | Elasticsearch Buffer comma-separated chunk keys                                | `""`                                               |
 | `elasticsearch.buffer.type`                          | Elasticsearch Buffer type                                                      | `file`                                             |

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -520,6 +520,7 @@ data:
 {{- else }}
       logstash_format "#{ENV['LOGSTASH_FORMAT']}"
       index_name "#{ENV['INDEX_NAME']}"
+      include_timestamp "#{ENV['INCLUDE_TIMESTAMP']}"
 {{- end }}
 {{- if .Values.elasticsearch.ilm.enabled }}
       enable_ilm "#{ENV['ENABLE_ILM']}"

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -148,6 +148,8 @@ spec:
         - name: OUTPUT_SUPPRESS_TYPE_NAME
           value: {{ .Values.elasticsearch.suppressTypeName | quote }}
 {{- end }}
+        - name: INCLUDE_TIMESTAMP
+          value: {{ .Values.elasticsearch.includeTimestamp | quote }}
         {{- if .Values.env }}
         {{- range $key, $value := .Values.env }}
         - name: {{ $key }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -125,6 +125,7 @@ elasticsearch:
   reloadConnections: false
   requestTimeout: "5s"
   suppressTypeName: false
+  includeTimestamp: false
   buffer:
     enabled: true
     # ref: https://docs.fluentd.org/configuration/buffer-section#chunk-keys


### PR DESCRIPTION
Signed-off-by: baczus <baczusc60@gmail.com>

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/{{ .GitHubOrg }}/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
# Which chart
fluentd-elasticsearch
# What this PR does / why we need it
Adds new parameter `include_timestamp` to include `@timestamp` field to the log in case of `logstash` is disabled. 
# Which issue this PR fixes

Closes #46 

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] All variables are documented in the charts README