### PR TITLE
Fix OUTPUT_(USER|PASSWORD) secrets usage

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.6.1
+version: 11.6.2
 appVersion: 3.1.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -71,8 +71,8 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `awsSigningSidecar.image.repository`                 | AWS signing sidecar repository image                                           | `abutaha/aws-es-proxy`                             |
 | `awsSigningSidecar.image.tag`                        | AWS signing sidecar repository tag                                             | `v1.0`                                             |
 | `elasticsearch.auth.enabled`                         | Elasticsearch Auth enabled                                                     | `false`                                            |
-| `elasticsearch.auth.user`                            | Elasticsearch Auth User                                                        | `""`                                               |
-| `elasticsearch.auth.password`                        | Elasticsearch Auth Password                                                    | `""`                                               |
+| `elasticsearch.auth.user`                            | Elasticsearch Auth User                                                        | `null`                                             |
+| `elasticsearch.auth.password`                        | Elasticsearch Auth Password                                                    | `null`                                             |
 | `elasticsearch.setOutputHostEnvVar`                  | Use `elasticsearch.hosts` (Disable this to manually configure hosts)           | `true`                                             |
 | `elasticsearch.hosts`                                | Elasticsearch Hosts List (host and port)                                       | `["elasticsearch-client:9200"]`                    |
 | `elasticsearch.includeTagKey`                        | Elasticsearch Including of Tag key                                             | `true`                                             |

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -53,8 +53,10 @@ spec:
         - name: OUTPUT_PATH
           value: {{ .Values.elasticsearch.path | quote }}
 {{- if .Values.elasticsearch.auth.enabled }}
+{{- if .Values.elasticsearch.auth.user }}
         - name: OUTPUT_USER
           value: {{ .Values.elasticsearch.auth.user | quote }}
+{{- end }}
 {{- if .Values.elasticsearch.auth.password }}
         - name: OUTPUT_PASSWORD
           value: {{ .Values.elasticsearch.auth.password | quote }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -60,8 +60,8 @@ resources: {}
 elasticsearch:
   auth:
     enabled: false
-    user: "yourUser"
-    password: "yourPass"
+    user: null
+    password: null
   includeTagKey: true
   setOutputHostEnvVar: true
   # If setOutputHostEnvVar is false this value is ignored


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/{{ .GitHubOrg }}/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
# Which chart
fluentd-elasticsearch

# What this PR does / why we need it
Previously if the user specified a secret with name `OUTPUT_USER` or `OUTPUT_PASSWORD` in `secrets` this lead to name clashes.

If I just set the `user` to `null` currently the env variable would still try to be set and lead to the following error:
> DaemonSet.apps "logging" is invalid: [spec.template.spec.containers[0].env[3].valueFrom: Invalid value: "": may not be specified when `value` is not empty, spec.template.spec.containers[0].env[4].valueFrom: Invalid value: "": may not be specified when `value` is not empty]

# Which issue this PR fixes
see above

# Special notes for your reviewer
The default values for `elasticsearch.auth.(user|password)` weren't correct in the README but since no one should be using the default values I don't think this should be considered an API breaking change?

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] All variables are documented in the charts README