### PR TITLE
[fluentd-elasticsearch] Remove YAML syntax cruft

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.7.1
+version: 11.7.2
 appVersion: 3.1.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -208,13 +208,13 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         args:
           - "-endpoint"
-          - "{{ .Values.elasticsearch.scheme }}://{{ index .Values.elasticsearch.hosts 0 }}",
+          - "{{ .Values.elasticsearch.scheme }}://{{ index .Values.elasticsearch.hosts 0 }}"
           - "-listen"
-          - "{{ .Values.awsSigningSidecar.network.address }}:{{ .Values.awsSigningSidecar.network.port }}",
+          - "{{ .Values.awsSigningSidecar.network.address }}:{{ .Values.awsSigningSidecar.network.port }}"
           - "-timeout"
-          - "{{ .Values.awsSigningSidecar.network.remoteReadTimeoutSeconds }}"]
+          - "{{ .Values.awsSigningSidecar.network.remoteReadTimeoutSeconds }}"
 {{- range $arg := .Values.awsSigningSidecar.args }}
-          - {{ $arg }}
+          - "{{ $arg }}"
 {{- end }}
         env:
         - name: PORT_NUM


### PR DESCRIPTION
# Which chart

fluentd-elasticsearch

# What this PR does / why we need it

Removes cruft from converting the list of arguments for the AWS sidecar from an inline list. YAML is remarkably flexible and can actually deal with most of this, but the stray `]` caused issues with extra arguments.

Sorry this has taken so many PRs; I'm new to all of this and it's taken me a while to figure out how to effectively test parts of it.

# Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] All variables are documented in the charts README