### PR TITLE
[fluentd-elasticsearch] Fix liveness probe logic to detect stuck elasticsearch buffers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Lint Code Base
         uses: github/super-linter@v3
         env:

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.9.0
+version: 11.9.1
 appVersion: 3.2.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -211,17 +211,20 @@ livenessProbe:
         STUCK_THRESHOLD_SECONDS=${STUCK_THRESHOLD_SECONDS:-900};
         if [ ! -e /var/log/fluentd-buffers ];
         then
+          echo "Expected directory /var/log/fluentd-buffers does not exist. This is likely a configuration issue.";
           exit 1;
         fi;
         touch -d "${STUCK_THRESHOLD_SECONDS} seconds ago" /tmp/marker-stuck;
-        if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-stuck -print -quit)" ];
+        if [ -n "$(find /var/log/fluentd-buffers -mindepth 1 -type d ! -newer /tmp/marker-stuck -print -quit)" ];
         then
+          echo "Elasticsearch buffers found stuck longer than $STUCK_THRESHOLD_SECONDS seconds. Clearing buffers."
           rm -rf /var/log/fluentd-buffers;
           exit 1;
         fi;
         touch -d "${LIVENESS_THRESHOLD_SECONDS} seconds ago" /tmp/marker-liveness;
-        if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-liveness -print -quit)" ];
+        if [ -n "$(find /var/log/fluentd-buffers -mindepth 1 -type d ! -newer /tmp/marker-liveness -print -quit)" ];
         then
+          echo "Elasticsearch buffers found stuck longer than $LIVENESS_THRESHOLD_SECONDS seconds."
           exit 1;
         fi;
 


### PR DESCRIPTION

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/{{ .GitHubOrg }}/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
# Which chart

fluentd-elasticsearch

# What this PR does / why we need it

This PR fixes a logic defect in the liveness probe for fluentd-elasticsearch, which causes fluentd pods deployed by this helm chart to be periodically killed needlessly. In environments with monitoring and alerting configured, this problem results in frequent alerts about fluentd being restarted.

Before this change, the liveness probe says:
```if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-stuck -print -quit)" ];```

This line tries to find buffers that are newer than the "stuck" marker file. If it doesn't find any (`-z` for empty string), it assumes that this means the buffer files are all older than the stuck marker and it causes liveness to fail. This logic *will* work to fail the liveness probe if there are stuck buffers. But it will also fail the liveness probe if there are *no* buffers, which is wrong.

After the change, the liveness probe says:
```if [ -n "$(find /var/log/fluentd-buffers -mindepth 1 -type d ! -newer /tmp/marker-stuck -print -quit)" ];```

This line looks for any files under the fluentd-buffers directory which are older (`! newer` - NOT newer) than the stuck marker and fails if any are found (`-n` non-empty string). The `-mindepth 1` tells `find` not to include the parent directory /var/log/fluentd-buffers itself. This logic will work to fail the liveness probe if there are stuck buffers. It will *not* fail the liveness prove if there are no buffers, which happens in low-volume situations.

This PR also adds `echo` statements to the failures, which greatly improves debuggability for Kubernetes operators. By adding this output, Kubernetes will include it on the Events which report the pod being killed.

# Which issue this PR fixes

- fixes #70 

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] All variables are documented in the charts README