### PR TITLE
[fluentd-elasticsearch] Allow use_legacy_template setting to be configured

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.9.1
+version: 11.10.0
 appVersion: 3.2.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -93,6 +93,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.template.file`                        | Elasticsearch Template File Name (inside the daemonset)                        | `fluentd-template.json`                            |
 | `elasticsearch.template.content`                     | Elasticsearch Template Content                                                 | _see `values.yaml`_                                |
 | `elasticsearch.template.overwrite`                   | Elasticsearch Template Overwrite (update even if it already exists)            | `false`                                            |
+| `elasticsearch.template.useLegacy`                   | Use legacy Elasticsearch template                                              | `true`                                             |
 | `elasticsearch.indexName`                            | Elasticsearch Index Name                                                       | `fluentd`                                          |
 | `elasticsearch.path`                                 | Elasticsearch Path                                                             | `""`                                               |
 | `elasticsearch.scheme`                               | Elasticsearch scheme setting                                                   | `http`                                             |

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -533,6 +533,7 @@ data:
       template_name "#{ENV['TEMPLATE_NAME']}"
       template_file "#{ENV['TEMPLATE_FILE']}"
       template_overwrite "#{ENV['TEMPLATE_OVERWRITE']}"
+      use_legacy_template "#{ENV['USE_LEGACY_TEMPLATE']}"
 {{- end }}
       log_es_400_reason "#{ENV['OUTPUT_LOG_400_REASON']}"
       reconnect_on_error "#{ENV['OUTPUT_RECONNECT_ON_ERROR']}"

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -97,6 +97,8 @@ spec:
           value: "/etc/fluent/config.d/{{ .Values.elasticsearch.template.file }}"
         - name: TEMPLATE_OVERWRITE
           value: {{ .Values.elasticsearch.template.overwrite | quote }}
+        - name: USE_LEGACY_TEMPLATE
+          value: {{ .Values.elasticsearch.template.useLegacy | quote }}
 {{- end }}
         - name: OUTPUT_SCHEME
           {{- if .Values.awsSigningSidecar.enabled }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -102,6 +102,7 @@ elasticsearch:
   template:
     enabled: false
     overwrite: false
+    useLegacy: true
     name: fluentd-template
     file: fluentd-template.json
     content: |-


### PR DESCRIPTION
# Which chart

fluentd-elasticsearch

# What this PR does / why we need it

Allow the [`use_legacy_template` setting](https://github.com/uken/fluent-plugin-elasticsearch/blob/v4.3.3/README.md#use_legacy_template) to be configured, so that we can use the new composable index templates rather than the deprecated legacy templates.

This parameter defaults to `true` in fluent-plugin-elasticsearch and needs to be set to `false` to use the new composable templates in Elasticsearch 7.8+.

# Special notes for your reviewer

I think the fluent-plugin-elasticsearch README is wrong in saying the parameter should be set to `false` for Elasticsearch 7.7 or older (see https://github.com/uken/fluent-plugin-elasticsearch/pull/880).

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] All variables are documented in the charts README