### PR TITLE
Allow extra envs to be set for the AWS Signing sidecar

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.11.0
+version: 11.11.1
 appVersion: 3.2.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.11.1
+version: 11.12.0
 appVersion: 3.2.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -64,6 +64,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `configMaps.useDefaults.outputConf`                  | Use default output.conf                                                        | `true`                                             |
 | `extraConfigMaps`                                    | Add additional Configmap or overwrite disabled default                         | `{}`                                               |
 | `awsSigningSidecar.enabled`                          | Enable AWS request signing sidecar                                             | `false`                                            |
+| `awsSigningSidecar.extraEnvs`                        | List of env vars that are added to the AWS signing sidecar pods                | `[]`                                               |
 | `awsSigningSidecar.resources`                        | AWS Sidecar resources                                                          | `{}`                                               |
 | `awsSigningSidecar.network.port`                     | AWS Sidecar exposure port                                                      | `8080`                                             |
 | `awsSigningSidecar.network.address`                  | AWS Sidecar listen address                                                     | `localhost`                                        |

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -227,6 +227,12 @@ spec:
         env:
         - name: PORT_NUM
           value: {{ .Values.awsSigningSidecar.network.port | quote }}
+        {{- if .Values.awsSigningSidecar.extraEnvs }}
+        {{- range $env := .Values.awsSigningSidecar.extraEnvs }}
+        - name: {{ $env.name }}
+          value: {{ $env.value | quote }}
+        {{- end }}
+        {{- end }}
         resources:
 {{ toYaml .Values.awsSigningSidecar.resources | indent 10 }}
         volumeMounts:

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -17,6 +17,12 @@ image:
 ## proxy that takes care of signing all requests being sent to the AWS ES Domain.
 awsSigningSidecar:
   enabled: false
+  # You can configure some features of AWS ES Proxy by passing specific environment
+  # variables. E.g. AWS EKS IRSA is supported by providing AWS_ROLE_ARN and
+  # AWS_WEB_IDENTITY_TOKEN_FILE
+  extraEnvs: []
+  # name: FOO
+  # value: BAR
   resources: {}
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/{{ .GitHubOrg }}/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
# Which chart
fluentd-elasticsearch

# What this PR does / why we need it
This PR adds the option to specify the extra environment variables to AWS Signing sidecar. You can configure some features of AWS ES Proxy by passing specific environment variables. E.g. AWS EKS IRSA is supported by providing AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE.

The README was also updated to document the new chart arguments.
I bumped the chart Minor version since this introduces a new feature.

# Which issue this PR fixes
N/A

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] All variables are documented in the charts README