### PR TITLE
[fluentd-elasticsearch] Issue 86: Configure PrometheusRules to match metrics service job name

### DIFF
--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -6,7 +6,7 @@
 set -o errexit
 set -o pipefail
 
-CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/main -- zammad | grep '[cC]hart.yaml' | sed -e 's#/[Cc]hart.yaml##g')"
+CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/main -- charts | grep '[cC]hart.yaml' | sed -e 's#/[Cc]hart.yaml##g')"
 SCHEMA_LOCATION="https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/"
 
 # install kubeval

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
       - 'charts/**/**'
 
 env:
-  helm-version: "v3.6.2"
+  helm-version: "v3.6.3"
   kubeval-version: "v0.16.1"
 
 jobs:
@@ -33,14 +33,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v1.1
         with:
           version: "${{ env.helm-version }}"
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.1.0
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml
 
@@ -80,7 +80,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v1.1
         with:
           version: "${{ env.helm-version }}"
       - name: Run kubeval
@@ -109,7 +109,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v1.1
         with:
           version: "${{ env.helm-version }}"
       - uses: actions/setup-python@v2
@@ -125,7 +125,7 @@ jobs:
             echo "::set-output name=changed::true"
           fi
       - name: Create kind cluster
-        uses: helm/kind-action@v1.1.0
+        uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
           config: .github/kind-config.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  helm-version: "v3.6.2"
+  helm-version: "v3.6.3"
 
 jobs:
   release:

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.13.0
+version: 11.14.0
 appVersion: 3.2.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -171,7 +171,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `serviceMonitor.labels`                              | Optional labels for serviceMonitor                                             | `{}`                                               |
 | `serviceMonitor.metricRelabelings`                   | Optional metric relabel configs to apply to samples before ingestion           | `[]`                                               |
 | `serviceMonitor.relabelings`                         | Optional relabel configs to apply to samples before scraping                   | `[]`                                               |
-| `serviceMonitor.jobLabel`                            | Label whose value will define the job name                                     | `app.kubernetes.io/instance`                       |
+| `serviceMonitor.jobLabel`                            | PrometheusRule jobLabel. Uses the created metrics service name if not set.     | Not Set                     |
 | `serviceMonitor.type`                                | Optional the type of the metrics service                                       | `ClusterIP`                                        |
 | `tolerations`                                        | Optional daemonset tolerations                                                 | `[]`                                               |
 | `updateStrategy`                                     | Optional daemonset update strategy                                             | `type: RollingUpdate`                              |

--- a/charts/fluentd-elasticsearch/templates/_helpers.tpl
+++ b/charts/fluentd-elasticsearch/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the metrics service
+*/}}
+{{- define "fluentd-elasticsearch.metricsServiceName" -}}
+{{- include "fluentd-elasticsearch.fullname" . }}-metrics
+{{- end }}

--- a/charts/fluentd-elasticsearch/templates/metrics-service.yaml
+++ b/charts/fluentd-elasticsearch/templates/metrics-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "fluentd-elasticsearch.fullname" $ }}-metrics
+  name: {{ include "fluentd-elasticsearch.metricsServiceName" . }}
   labels:
     {{- include "fluentd-elasticsearch.labels" . | nindent 4 }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -283,7 +283,6 @@ serviceMonitor:
   labels: {}
   metricRelabelings: []
   relabelings: []
-  jobLabel: "app.kubernetes.io/instance"
   type: ClusterIP
 
 serviceMetric:
@@ -301,7 +300,7 @@ prometheusRule:
   labels: {}
   rules:
   - alert: FluentdNodeDown
-    expr: up{job="{{ include "fluentd-elasticsearch.fullname" . }}"} == 0
+    expr: up{job="{{ include "fluentd-elasticsearch.metricsServiceName" . }}"} == 0
     for: 10m
     labels:
       service: fluentd
@@ -310,7 +309,7 @@ prometheusRule:
       summary: fluentd cannot be scraped
       description: Prometheus could not scrape {{ "{{ $labels.job }}" }} for more than 10 minutes
   - alert: FluentdNodeDown
-    expr: up{job="{{ include "fluentd-elasticsearch.fullname" . }}"} == 0
+    expr: up{job="{{ include "fluentd-elasticsearch.metricsServiceName" . }}"} == 0
     for: 30m
     labels:
       service: fluentd
@@ -338,8 +337,8 @@ prometheusRule:
       description: In the last 5 minutes, fluentd queues increased 50%. Current value is {{ "{{ $value }}" }}
   - alert: FluentdRecordsCountsHigh
     expr: >
-      sum(rate(fluentd_output_status_emit_records{job="{{ tpl .Release.Name . }}"}[5m]))
-      BY (instance) >  (3 * sum(rate(fluentd_output_status_emit_records{job="{{ tpl .Release.Name . }}"}[15m]))
+      sum(rate(fluentd_output_status_emit_records{job="{{ include "fluentd-elasticsearch.metricsServiceName" . }}"}[5m]))
+      BY (instance) >  (3 * sum(rate(fluentd_output_status_emit_records{job="{{ include "fluentd-elasticsearch.metricsServiceName" . }}"}[15m]))
       BY (instance))
     for: 1m
     labels:


### PR DESCRIPTION
# Which chart

fluentd-elasticsearch

# What this PR does / why we need it

The PromQL queries in this helm chart's PrometheusRules don't match the metric labels exported by the configured metrics service. This PR fixes that problem with a few changes:
1. A new helper variable is defined to configure the metrics service name to keep the code DRY, `fluentd-elasticsearch.metricsServiceName`.
2. The metrics service uses the new helper variable to set the service name.
3. The `serviceMonitor.jobLabel` variable in this helm chart is defaulted to `Not Set`, which causes the `job` label of any exposed metrics to have the expected value for ServiceMonitor jobs... namely the name of the metrics service.
4. The PromQL in the PrometheusRules CRD is updated to query based on a job name matching the metrics service name.
5. Updated the README to reflect the new default value of `serviceMonitor.jobLabel`.

I tested this issue in my own cluster and verified that it deploys and works correctly.

# Which issue this PR fixes

- fixes #86

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] All variables are documented in the charts README