### PR TITLE
Fix #25: Support for sidecars and init containers.

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.15.0
+version: 11.16.0
 appVersion: 3.3.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 11.16.0
+version: 12.0.0
 appVersion: 3.3.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -127,6 +127,8 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `fluentdArgs`                                        | Fluentd args                                                                   | `--no-supervisor -q`                               |
 | `fluentdLogFormat`                                   | Fluentd output log format in the default system.conf (either "text" or "json") | `text`                                             |
 | `secret`                                             | List of env vars that are set from secrets and added to the fluentd pods       | `[]`                                               |
+| `extraContainers`                                    | Add sidecar containers to each pod in the daemonset                            | `[]`                                               |
+| `extraInitContainers`                                | Add init containers to each pod in the daemonset                               | `[]`                                               |
 | `extraVolumeMounts`                                  | Mount extra volume, required to mount ssl certificates when ES has tls enabled | `[]`                                               |
 | `extraVolumes`                                       | Extra volume                                                                   | `[]`                                               |
 | `fluentConfDir`                                      | Specify where to mount fluentd location                                        | `/etc/fluent/config.d`                             |

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -202,7 +202,8 @@ extraVolumes: |
 
 ### AWS Elasticsearch Domains
 
-AWS Elasticsearch requires requests to upload data to be signed using [AWS Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). In order to support this, you can add a sidecar to the `extraContainers` configuration. An example is provided in `values.yaml`. This results in a sidecar container being deployed that proxies all requests to your Elasticsearch domain and signs them appropriately.
+AWS Elasticsearch requires requests to upload data to be signed using [AWS Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). In order to support this, you can add a sidecar to the `extraContainers` configuration. An example is provided in `values.yaml`. This results in a sidecar container being deployed that proxies all requests to your Elasticsearch domain
+and signs them appropriately.
 
 ## Upgrading
 

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -347,3 +347,7 @@ In this version elasticsearch template in `output.conf` configmap was expanded t
 ### From a version < 10.0.0 to version => 11.0.0
 
 The chart requires now Helm >= 3.0.0 and Kubernetes >= 1.16.0
+
+### From a version < 11.0.0 to version => 12.0.0
+
+If you were using `awsSigningSidecar` to set up an AWS signing sidecar proxy, this has now moved to the `extraContainers` property. The example in the `values.yaml` shows the equivalent AWS signing sidecar configuration expressed now as `extraContainers`.

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -63,15 +63,6 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `configMaps.useDefaults.monitoringConf`              | Use default monitoring.conf                                                    | `true`                                             |
 | `configMaps.useDefaults.outputConf`                  | Use default output.conf                                                        | `true`                                             |
 | `extraConfigMaps`                                    | Add additional Configmap or overwrite disabled default                         | `{}`                                               |
-| `awsSigningSidecar.enabled`                          | Enable AWS request signing sidecar                                             | `false`                                            |
-| `awsSigningSidecar.extraEnvs`                        | List of env vars that are added to the AWS signing sidecar pods                | `[]`                                               |
-| `awsSigningSidecar.resources`                        | AWS Sidecar resources                                                          | `{}`                                               |
-| `awsSigningSidecar.network.port`                     | AWS Sidecar exposure port                                                      | `8080`                                             |
-| `awsSigningSidecar.network.address`                  | AWS Sidecar listen address                                                     | `localhost`                                        |
-| `awsSigningSidecar.network.remoteReadTimeoutSeconds` | AWS Sidecar socket read timeout when talking to ElasticSearch                  | `15`                                               |
-| `awsSigningSidecar.image.repository`                 | AWS signing sidecar repository image                                           | `abutaha/aws-es-proxy`                             |
-| `awsSigningSidecar.image.tag`                        | AWS signing sidecar repository tag                                             | `v1.0`                                             |
-| `awsSigningSidecar.args`                             | Additional command-line arguments for the AWS signing sidecar container        | `[]`                                               |
 | `elasticsearch.auth.enabled`                         | Elasticsearch Auth enabled                                                     | `false`                                            |
 | `elasticsearch.auth.user`                            | Elasticsearch Auth User                                                        | `null`                                             |
 | `elasticsearch.auth.password`                        | Elasticsearch Auth Password                                                    | `null`                                             |
@@ -211,7 +202,7 @@ extraVolumes: |
 
 ### AWS Elasticsearch Domains
 
-AWS Elasticsearch requires requests to upload data to be signed using [AWS Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). In order to support this, you can add `awsSigningSidecar: {enabled: true}` to your configuration. This results in a sidecar container being deployed that proxies all requests to your Elasticsearch domain and signs them appropriately.
+AWS Elasticsearch requires requests to upload data to be signed using [AWS Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). In order to support this, you can add a sidecar to the `extraSidecars` configuration. An example is provided in `values.yaml`. This results in a sidecar container being deployed that proxies all requests to your Elasticsearch domain and signs them appropriately.
 
 ## Upgrading
 

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -202,7 +202,7 @@ extraVolumes: |
 
 ### AWS Elasticsearch Domains
 
-AWS Elasticsearch requires requests to upload data to be signed using [AWS Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). In order to support this, you can add a sidecar to the `extraSidecars` configuration. An example is provided in `values.yaml`. This results in a sidecar container being deployed that proxies all requests to your Elasticsearch domain and signs them appropriately.
+AWS Elasticsearch requires requests to upload data to be signed using [AWS Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). In order to support this, you can add a sidecar to the `extraContainers` configuration. An example is provided in `values.yaml`. This results in a sidecar container being deployed that proxies all requests to your Elasticsearch domain and signs them appropriately.
 
 ## Upgrading
 

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -44,11 +44,7 @@ spec:
           value: {{ .Values.fluentdArgs | quote }}
         {{- if .Values.elasticsearch.setOutputHostEnvVar }}
         - name: OUTPUT_HOSTS
-          {{- if .Values.awsSigningSidecar.enabled }}
-          value: "{{ .Values.awsSigningSidecar.network.address }}:{{ .Values.awsSigningSidecar.network.port }}"
-          {{- else }}
           value: "{{- join "," .Values.elasticsearch.hosts }}"
-          {{- end }}
         {{- end }}
         - name: OUTPUT_PATH
           value: {{ .Values.elasticsearch.path | quote }}
@@ -101,11 +97,7 @@ spec:
           value: {{ .Values.elasticsearch.template.useLegacy | quote }}
 {{- end }}
         - name: OUTPUT_SCHEME
-          {{- if .Values.awsSigningSidecar.enabled }}
-          value: 'http'
-          {{- else }}
           value: {{ .Values.elasticsearch.scheme | quote }}
-          {{- end }}
         - name: OUTPUT_TYPE
           value: {{ .Values.elasticsearch.outputType | quote }}
         - name: OUTPUT_SSL_VERIFY
@@ -210,33 +202,6 @@ spec:
             protocol: {{ $port.protocol }}
 {{- end }}
 {{- end }}
-      {{- if .Values.awsSigningSidecar.enabled }}
-      - name: {{ include "fluentd-elasticsearch.fullname" . }}-aws-es-proxy
-        image: {{ .Values.awsSigningSidecar.image.repository }}:{{ .Values.awsSigningSidecar.image.tag }}
-        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        args:
-          - "-endpoint"
-          - "{{ .Values.elasticsearch.scheme }}://{{ index .Values.elasticsearch.hosts 0 }}"
-          - "-listen"
-          - "{{ .Values.awsSigningSidecar.network.address }}:{{ .Values.awsSigningSidecar.network.port }}"
-          - "-timeout"
-          - "{{ .Values.awsSigningSidecar.network.remoteReadTimeoutSeconds }}"
-{{- range $arg := .Values.awsSigningSidecar.args }}
-          - "{{ $arg }}"
-{{- end }}
-        env:
-        - name: PORT_NUM
-          value: {{ .Values.awsSigningSidecar.network.port | quote }}
-        {{- if .Values.awsSigningSidecar.extraEnvs }}
-        {{- range $env := .Values.awsSigningSidecar.extraEnvs }}
-        - name: {{ $env.name }}
-          value: {{ $env.value | quote }}
-        {{- end }}
-        {{- end }}
-        resources:
-{{ toYaml .Values.awsSigningSidecar.resources | indent 10 }}
-        volumeMounts:
-      {{- end }}
 {{- if .Values.extraContainers }}
 {{ toYaml .Values.extraContainers | indent 6 }}
 {{- end }}

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -237,6 +237,13 @@ spec:
 {{ toYaml .Values.awsSigningSidecar.resources | indent 10 }}
         volumeMounts:
       {{- end }}
+{{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 6 }}
+{{- end }}
+{{- if .Values.extraInitContainers }}
+      initContainers:
+{{ toYaml .Values.extraInitContainers | indent 6 }}
+{{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -12,33 +12,6 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
-## If using AWS Elasticsearch, all requests to ES need to be signed regardless of whether
-## one is using Cognito or not. By setting this to true, this chart will install a sidecar
-## proxy that takes care of signing all requests being sent to the AWS ES Domain.
-awsSigningSidecar:
-  enabled: false
-  # You can configure some features of AWS ES Proxy by passing specific environment
-  # variables. E.g. AWS EKS IRSA is supported by providing AWS_ROLE_ARN and
-  # AWS_WEB_IDENTITY_TOKEN_FILE
-  extraEnvs: []
-  # name: FOO
-  # value: BAR
-  resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 500Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 200Mi
-  network:
-    port: 8080
-    address: localhost
-    remoteReadTimeoutSeconds: 15
-  image:
-    repository: abutaha/aws-es-proxy
-    tag: v1.0
-  args: []
-
 # Specify to use specific priorityClass for pods
 # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 # If a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority
@@ -74,7 +47,9 @@ elasticsearch:
       key: null
   includeTagKey: true
   setOutputHostEnvVar: true
-  # If setOutputHostEnvVar is false this value is ignored
+  # If setOutputHostEnvVar is false the hosts value is ignored
+  # If you are configuring an AWS signing sidecar, hosts should be the network
+  # address of the sidecar, like "localhost:8080"
   hosts: ["elasticsearch-client:9200"]
   indexName: "fluentd"
   logstash:
@@ -124,6 +99,7 @@ elasticsearch:
       }
 
   path: ""
+  # If you are configuring an AWS signing sidecar, scheme should be "http"
   scheme: "http"
   sslVerify: true
   sslVersion: "TLSv1_2"
@@ -386,22 +362,51 @@ extraConfigMaps: {}
   #   </system>
 
 extraVolumes: []
-#   - name: es-certs
-#     secret:
-#       defaultMode: 420
-#       secretName: es-certs
+# - name: es-certs
+#   secret:
+#     defaultMode: 420
+#     secretName: es-certs
 
 extraVolumeMounts: []
-#   - name: es-certs
-#     mountPath: /certs
-#     readOnly: true
+# - name: es-certs
+#   mountPath: /certs
+#   readOnly: true
 
-extraContainers: []
-#   - name: do-something
-#     image: busybox
-#     command: ['do', 'something']
+## Sidecar containers
+##
+## If using AWS Elasticsearch, all requests to ES need to be signed regardless
+## of whether one is using Cognito or not. The example here shows how to
+## configure a sidecar proxy that takes care of signing all requests being sent
+## to the AWS ES Domain.
+extraContainers: # []
+# - name: aws-es-proxy
+#   image: abutaha/aws-es-proxy:v1.0
+#   imagePullPolicy: IfNotPresent
+#   args:
+#   - "-endpoint"
+#   # Put your ElasticSearch host here as the endpoint and set...
+#   # elasticsearch.hosts location to the sidecar address, e.g. localhost:8080
+#   # elasticsearch.scheme to http
+#   - "http://elasticsearch-client:9200"
+#   - "-listen"
+#   - "localhost:8080"
+#   - "-timeout"
+#   - "15"
+#   # You can configure some features of AWS ES Proxy by passing specific
+#   # environment variables. E.g. AWS EKS IRSA is supported by providing
+#   # AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE
+#   env:
+#   - name: PORT_NUM
+#     value: "8080"
+#   resources:
+#     limits:
+#       cpu: 100m
+#       memory: 500Mi
+#     requests:
+#       cpu: 100m
+#       memory: 200Mi
 
 extraInitContainers: []
-#   - name: do-something
-#     image: busybox
-#     command: ['do', 'something']
+# - name: do-something
+#   image: busybox
+#   command: ['do', 'something']

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -378,7 +378,7 @@ extraVolumeMounts: []
 ## of whether one is using Cognito or not. The example here shows how to
 ## configure a sidecar proxy that takes care of signing all requests being sent
 ## to the AWS ES Domain.
-extraContainers: # []
+extraContainers: []
 # - name: aws-es-proxy
 #   image: abutaha/aws-es-proxy:v1.0
 #   imagePullPolicy: IfNotPresent

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -395,3 +395,13 @@ extraVolumeMounts: []
 #   - name: es-certs
 #     mountPath: /certs
 #     readOnly: true
+
+extraContainers: []
+#   - name: do-something
+#     image: busybox
+#     command: ['do', 'something']
+
+extraInitContainers: []
+#   - name: do-something
+#     image: busybox
+#     command: ['do', 'something']


### PR DESCRIPTION
Signed-off-by: Travis Illig <tillig@paraesthesia.com>

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/{{ .GitHubOrg }}/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
# Which chart
`fluentd-elasticsearch` (@monotek)

# What this PR does / why we need it
Enables sidecar and init container support in a similar fashion to the [ElasticSearch charts](https://github.com/elastic/helm-charts/blob/09828a9ce85346d34e1bd27e1b8072423163b978/elasticsearch/templates/statefulset.yaml#L369). This is useful in situations where you need sidecars similar to the AWS signing sidecar but which aren't specific to AWS. For example, Istio service mesh can be used to enable TLS for ElasticSearch and manage the certificates - adding the sidecar manually and mounting a shared volume is how you get the certificates in here for use.

# Which issue this PR fixes

- fixes #25

# Special notes for your reviewer

none

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] All variables are documented in the charts README