### PR TITLE
Updated depricated fluentd buffer parameter

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 12.0.0
+version: 13.0.0
 appVersion: 3.3.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -112,7 +112,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.buffer.retryForever`                  | Elasticsearch Buffer retry forever                                             | `true`                                             |
 | `elasticsearch.buffer.retryMaxInterval`              | Elasticsearch Buffer retry max interval                                        | `30`                                               |
 | `elasticsearch.buffer.chunkLimitSize`                | Elasticsearch Buffer chunk limit size                                          | `2M`                                               |
-| `elasticsearch.buffer.queueLimitLength`              | Elasticsearch Buffer queue limit size                                          | `8`                                                |
+| `elasticsearch.buffer.totalLimitSize`                | Elasticsearch Buffer queue limit size                                          | `512M`                                             |
 | `elasticsearch.buffer.overflowAction`                | Elasticsearch Buffer over flow action                                          | `block`                                            |
 | `env`                                                | List of env vars that are added to the fluentd pods                            | `{}`                                               |
 | `fluentdArgs`                                        | Fluentd args                                                                   | `--no-supervisor -q`                               |
@@ -352,3 +352,9 @@ The chart requires now Helm >= 3.0.0 and Kubernetes >= 1.16.0
 ### From a version < 11.0.0 to version => 12.0.0
 
 If you were using `awsSigningSidecar` to set up an AWS signing sidecar proxy, this has now moved to the `extraContainers` property. The example in the `values.yaml` shows the equivalent AWS signing sidecar configuration expressed now as `extraContainers`.
+
+### From a version < 12.0.0 to version => 13.0.0
+
+#### The following fields were changed in the elasticsearch block
+
+- `buffer.queueLimitLength` in favor of `buffer.totalLimitSize` since `queueLimitLength` [is deprecated](https://docs.fluentd.org/configuration/buffer-section#buffering-parameters).

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -561,7 +561,7 @@ data:
         retry_forever "#{ENV['OUTPUT_BUFFER_RETRY_FOREVER']}"
         retry_max_interval "#{ENV['OUTPUT_BUFFER_RETRY_MAX_INTERVAL']}"
         chunk_limit_size "#{ENV['OUTPUT_BUFFER_CHUNK_LIMIT']}"
-        queue_limit_length "#{ENV['OUTPUT_BUFFER_QUEUE_LIMIT']}"
+        total_limit_size "#{ENV['OUTPUT_BUFFER_TOTAL_LIMIT_SIZE']}"
         overflow_action "#{ENV['OUTPUT_BUFFER_OVERFLOW_ACTION']}"
       </buffer>
 {{- end }}

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -108,8 +108,8 @@ spec:
           value: {{ .Values.elasticsearch.typeName | quote }}
         - name: OUTPUT_BUFFER_CHUNK_LIMIT
           value: {{ .Values.elasticsearch.buffer.chunkLimitSize | quote }}
-        - name: OUTPUT_BUFFER_QUEUE_LIMIT
-          value: {{ .Values.elasticsearch.buffer.queueLimitLength | quote }}
+        - name: OUTPUT_BUFFER_TOTAL_LIMIT_SIZE
+          value: {{ .Values.elasticsearch.buffer.totalLimitSize | quote }}
           {{- if .Values.elasticsearch.buffer.chunkKeys }}
         - name: OUTPUT_BUFFER_CHUNK_KEYS
           value: {{ .Values.elasticsearch.buffer.chunkKeys | quote }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -126,7 +126,7 @@ elasticsearch:
     retryForever: true
     retryMaxInterval: 30
     chunkLimitSize: "2M"
-    queueLimitLength: 8
+    totalLimitSize: "512M"
     overflowAction: "block"
 
 # If you want to change args of fluentd process


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/{{ .GitHubOrg }}/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
# Which chart

fluentd-elasticsearch

# What this PR does / why we need it

Updated the depricated fluentd buffer parameter `queue_limit_length` to instead use the new parameter `total_limit_size`

Source: https://docs.fluentd.org/configuration/buffer-section#buffering-parameters

# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes None

# Special notes for your reviewer

I used the same default size for the buffer as the one stated in the fluentd documentation but for the memory type since I saw that most defaults here are lower than fluentd defaults. 

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] All variables are documented in the charts README