### PR TITLE
[fluentd-elasticsearch] Support arbitrary config for kubernetes_metadata

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 13.0.0
+version: 13.1.0
 appVersion: 3.3.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -50,124 +50,125 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Fluentd elasticsearch chart and their default values.
 
-| Parameter                                            | Description                                                                    | Default                                            |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------- |
-| `affinity`                                           | Optional daemonset affinity                                                    | `{}`                                               |
-| `annotations`                                        | Optional daemonset annotations                                                 | `NULL`                                             |
-| `podAnnotations`                                     | Optional daemonset's pods annotations                                          | `NULL`                                             |
-| `configMaps.useDefaults.systemConf`                  | Use default system.conf                                                        | `true`                                             |
-| `configMaps.useDefaults.containersInputConf`         | Use default containers.input.conf                                              | `true`                                             |
-| `configMaps.useDefaults.containersKeepTimeKey`       | Keep the container log timestamp as part of the log data.                      | `false`                                            |
-| `configMaps.useDefaults.systemInputConf`             | Use default system.input.conf                                                  | `true`                                             |
-| `configMaps.useDefaults.forwardInputConf`            | Use default forward.input.conf                                                 | `true`                                             |
-| `configMaps.useDefaults.monitoringConf`              | Use default monitoring.conf                                                    | `true`                                             |
-| `configMaps.useDefaults.outputConf`                  | Use default output.conf                                                        | `true`                                             |
-| `extraConfigMaps`                                    | Add additional Configmap or overwrite disabled default                         | `{}`                                               |
-| `elasticsearch.auth.enabled`                         | Elasticsearch Auth enabled                                                     | `false`                                            |
-| `elasticsearch.auth.user`                            | Elasticsearch Auth User                                                        | `null`                                             |
-| `elasticsearch.auth.password`                        | Elasticsearch Auth Password                                                    | `null`                                             |
-| `elasticsearch.auth.existingSecret.name`             | Name of secret                                                                 | `null`                                             |
-| `elasticsearch.auth.existingSecret.key`              | Key within secret containing password                                          | `null`                                             |
-| `elasticsearch.setOutputHostEnvVar`                  | Use `elasticsearch.hosts` (Disable this to manually configure hosts)           | `true`                                             |
-| `elasticsearch.hosts`                                | Elasticsearch Hosts List (host and port)                                       | `["elasticsearch-client:9200"]`                    |
-| `elasticsearch.includeTagKey`                        | Elasticsearch Including of Tag key                                             | `true`                                             |
-| `elasticsearch.logstash.enabled`                     | Elasticsearch Logstash enabled (supersedes indexName)                          | `true`                                             |
-| `elasticsearch.logstash.prefix`                      | Elasticsearch Logstash prefix                                                  | `logstash`                                         |
-| `elasticsearch.logstash.prefixSeparator`             | Elasticsearch Logstash prefix separator                                        | `-`                                                |
-| `elasticsearch.logstash.dateformat`                  | Elasticsearch Logstash strftime format to generate index target index name     | `%Y.%m.%d`                                         |
-| `elasticsearch.ilm.enabled`                          | Elasticsearch Index Lifecycle Management enabled                               | `false`                                            |
-| `elasticsearch.ilm.policy_id`                        | Elasticsearch ILM policy ID                                                    | `logstash-policy`                                  |
-| `elasticsearch.ilm.policy`                           | Elasticsearch ILM policy to create                                             | `{}`                                               |
-| `elasticsearch.ilm.policies`                         | Elasticsearch ILM policies to create, map of policy IDs and policies           | `{}`                                               |
-| `elasticsearch.ilm.policy_overwrite`                 | Elastichsarch ILM policy overwrite                                             | `false`                                            |
-| `elasticsearch.template.enabled`                     | Elastichsarch Template enabled                                                 | `false`                                            |
-| `elasticsearch.template.name`                        | Elastichsarch Template Name                                                    | `fluentd-template`                                 |
-| `elasticsearch.template.file`                        | Elasticsearch Template File Name (inside the daemonset)                        | `fluentd-template.json`                            |
-| `elasticsearch.template.content`                     | Elasticsearch Template Content                                                 | _see `values.yaml`_                                |
-| `elasticsearch.template.overwrite`                   | Elasticsearch Template Overwrite (update even if it already exists)            | `false`                                            |
-| `elasticsearch.template.useLegacy`                   | Use legacy Elasticsearch template                                              | `true`                                             |
-| `elasticsearch.indexName`                            | Elasticsearch Index Name                                                       | `fluentd`                                          |
-| `elasticsearch.path`                                 | Elasticsearch Path                                                             | `""`                                               |
-| `elasticsearch.scheme`                               | Elasticsearch scheme setting                                                   | `http`                                             |
-| `elasticsearch.sslVerify`                            | Elasticsearch Auth SSL verify                                                  | `true`                                             |
-| `elasticsearch.sslVersion`                           | Elasticsearch tls version setting                                              | `TLSv1_2`                                          |
-| `elasticsearch.outputType`                           | Elasticsearch output type                                                      | `elasticsearch`                                    |
-| `elasticsearch.typeName`                             | Elasticsearch type name                                                        | `_doc`                                             |
-| `elasticsearch.logLevel`                             | Elasticsearch global log level                                                 | `info`                                             |
-| `elasticsearch.log400Reason`                         | Elasticsearch Log 400 reason                                                   | `false`                                            |
-| `elasticsearch.reconnectOnError`                     | Elasticsearch Reconnect on error                                               | `true`                                             |
-| `elasticsearch.reloadOnFailure`                      | Elasticsearch Reload on failure                                                | `false`                                            |
-| `elasticsearch.reloadConnections`                    | Elasticsearch reload connections                                               | `false`                                            |
-| `elasticsearch.requestTimeout`                       | Elasticsearch request timeout                                                  | `5s`                                               |
-| `elasticsearch.suppressTypeName`                     | Elasticsearch type name suppression (for ES >= 7)                              | `false`                                            |
-| `elasticsearch.includeTimestamp`                     | Elasticsearch Include timestamp (param used only if logstash is disabled)      | `false`                                            |
-| `elasticsearch.buffer.enabled`                       | Elasticsearch Buffer enabled                                                   | `true`                                             |
-| `elasticsearch.buffer.chunkKeys`                     | Elasticsearch Buffer comma-separated chunk keys                                | `""`                                               |
-| `elasticsearch.buffer.type`                          | Elasticsearch Buffer type                                                      | `file`                                             |
-| `elasticsearch.buffer.path`                          | Elasticsearch Buffer path                                                      | `/var/log/fluentd-buffers/kubernetes.system.buffer`|
-| `elasticsearch.buffer.flushMode`                     | Elasticsearch Buffer flush mode                                                | `interval`                                         |
-| `elasticsearch.buffer.retryType`                     | Elasticsearch Buffer retry type                                                | `exponential_backoff`                              |
-| `elasticsearch.buffer.flushThreadCount`              | Elasticsearch Buffer flush thread count                                        | `2`                                                |
-| `elasticsearch.buffer.flushInterval`                 | Elasticsearch Buffer flush interval                                            | `5s`                                               |
-| `elasticsearch.buffer.retryForever`                  | Elasticsearch Buffer retry forever                                             | `true`                                             |
-| `elasticsearch.buffer.retryMaxInterval`              | Elasticsearch Buffer retry max interval                                        | `30`                                               |
-| `elasticsearch.buffer.chunkLimitSize`                | Elasticsearch Buffer chunk limit size                                          | `2M`                                               |
-| `elasticsearch.buffer.totalLimitSize`                | Elasticsearch Buffer queue limit size                                          | `512M`                                             |
-| `elasticsearch.buffer.overflowAction`                | Elasticsearch Buffer over flow action                                          | `block`                                            |
-| `env`                                                | List of env vars that are added to the fluentd pods                            | `{}`                                               |
-| `fluentdArgs`                                        | Fluentd args                                                                   | `--no-supervisor -q`                               |
-| `fluentdLogFormat`                                   | Fluentd output log format in the default system.conf (either "text" or "json") | `text`                                             |
-| `secret`                                             | List of env vars that are set from secrets and added to the fluentd pods       | `[]`                                               |
-| `extraContainers`                                    | Add sidecar containers to each pod in the daemonset                            | `[]`                                               |
-| `extraInitContainers`                                | Add init containers to each pod in the daemonset                               | `[]`                                               |
-| `extraVolumeMounts`                                  | Mount extra volume, required to mount ssl certificates when ES has tls enabled | `[]`                                               |
-| `extraVolumes`                                       | Extra volume                                                                   | `[]`                                               |
-| `fluentConfDir`                                      | Specify where to mount fluentd location                                        | `/etc/fluent/config.d`                             |
-| `hostLogDir.varLog`                                  | Specify where fluentd can find var log                                         | `/var/log`                                         |
-| `hostLogDir.dockerContainers`                        | Specify where fluentd can find logs for docker container                       | `/var/lib/docker/containers`                       |
-| `hostLogDir.libSystemdDir`                           | Specify where fluentd can find logs for lib Systemd                            | `/usr/lib64`                                       |
-| `image.repository`                                   | Image                                                                          | `quay.io/fluentd_elasticsearch/fluentd`            |
-| `image.tag`                                          | Image tag                                                                      | `v3.3.0`                                           |
-| `image.pullPolicy`                                   | Image pull policy                                                              | `IfNotPresent`                                     |
-| `image.pullSecrets`                                  | Image pull secrets                                                             | ``                                                 |
-| `livenessProbe.enabled`                              | Whether to enable livenessProbe                                                | `true`                                             |
-| `livenessProbe.initialDelaySeconds`                  | livenessProbe initial delay seconds                                            | `600`                                              |
-| `livenessProbe.periodSeconds`                        | livenessProbe period seconds                                                   | `60`                                               |
-| `livenessProbe.kind`                                 | livenessProbe kind                                                             | `Set to a Linux compatible command`                |
-| `nodeSelector`                                       | Optional daemonset nodeSelector                                                | `{}`                                               |
-| `podSecurityPolicy.annotations`                      | Specify pod annotations in the pod security policy                             | `{}`                                               |
-| `podSecurityPolicy.enabled`                          | Specify if a pod security policy must be created                               | `false`                                            |
-| `priorityClassName`                                  | Optional PriorityClass for pods                                                | `""`                                               |
-| `prometheusRule.enabled`                             | Whether to enable Prometheus prometheusRule                                    | `false`                                            |
-| `prometheusRule.prometheusNamespace`                 | Namespace for prometheusRule                                                   | `monitoring`                                       |
-| `prometheusRule.labels`                              | Optional labels for prometheusRule                                             | `{}`                                               |
-| `rbac.create`                                        | RBAC                                                                           | `true`                                             |
-| `resources.limits.cpu`                               | CPU limit                                                                      | `100m`                                             |
-| `resources.limits.memory`                            | Memory limit                                                                   | `500Mi`                                            |
-| `resources.requests.cpu`                             | CPU request                                                                    | `100m`                                             |
-| `resources.requests.memory`                          | Memory request                                                                 | `200Mi`                                            |
-| `service`                                            | Service definition                                                             | `{}`                                               |
-| `service.ports`                                      | List of service ports dict [{name:...}...]                                     | Not Set                                            |
-| `service.ports[].type`                               | Service type (ClusterIP/NodePort)                                              | `ClusterIP`                                        |
-| `service.ports[].name`                               | One of service ports name                                                      | Not Set                                            |
-| `service.ports[].port`                               | Service port                                                                   | Not Set                                            |
-| `service.ports[].nodePort`                           | NodePort port (when service.type is NodePort)                                  | Not Set                                            |
-| `service.ports[].protocol`                           | Service protocol(optional, can be TCP/UDP)                                     | Not Set                                            |
-| `serviceAccount.create`                              | Specifies whether a service account should be created.                         | `true`                                             |
-| `serviceAccount.name`                                | Name of the service account.                                                   | `""`                                               |
-| `serviceAccount.annotations`                         | Specify annotations in the pod service account                                 | `{}`                                               |
-| `serviceMetric.enabled`                              | Generate the metric service regardless of whether serviceMonitor is enabled.   | `false`                                            |
-| `serviceMonitor.enabled`                             | Whether to enable Prometheus serviceMonitor                                    | `false`                                            |
-| `serviceMonitor.port`                                | Define on which port the ServiceMonitor should scrape                          | `24231`                                            |
-| `serviceMonitor.interval`                            | Interval at which metrics should be scraped                                    | `10s`                                              |
-| `serviceMonitor.path`                                | Path for Metrics                                                               | `/metrics`                                         |
-| `serviceMonitor.labels`                              | Optional labels for serviceMonitor                                             | `{}`                                               |
-| `serviceMonitor.metricRelabelings`                   | Optional metric relabel configs to apply to samples before ingestion           | `[]`                                               |
-| `serviceMonitor.relabelings`                         | Optional relabel configs to apply to samples before scraping                   | `[]`                                               |
-| `serviceMonitor.jobLabel`                            | PrometheusRule jobLabel. Uses the created metrics service name if not set.     | Not Set                     |
-| `serviceMonitor.type`                                | Optional the type of the metrics service                                       | `ClusterIP`                                        |
-| `tolerations`                                        | Optional daemonset tolerations                                                 | `[]`                                               |
-| `updateStrategy`                                     | Optional daemonset update strategy                                             | `type: RollingUpdate`                              |
+| Parameter                                               | Description                                                                       | Default                                             |
+| ----------------------------------------------------    | ------------------------------------------------------------------------------    | --------------------------------------------------  |
+| `affinity`                                              | Optional daemonset affinity                                                       | `{}`                                                |
+| `annotations`                                           | Optional daemonset annotations                                                    | `NULL`                                              |
+| `podAnnotations`                                        | Optional daemonset's pods annotations                                             | `NULL`                                              |
+| `configMaps.useDefaults.systemConf`                     | Use default system.conf                                                           | `true`                                              |
+| `configMaps.useDefaults.containersInputConf`            | Use default containers.input.conf                                                 | `true`                                              |
+| `configMaps.useDefaults.containersKeepTimeKey`          | Keep the container log timestamp as part of the log data.                         | `false`                                             |
+| `configMaps.useDefaults.kubernetesMetadataFilterConfig` | Set arbitrary configuration key-value pairs for the `kubernetes_metadata` filter. | `{}`                                                |
+| `configMaps.useDefaults.systemInputConf`                | Use default system.input.conf                                                     | `true`                                              |
+| `configMaps.useDefaults.forwardInputConf`               | Use default forward.input.conf                                                    | `true`                                              |
+| `configMaps.useDefaults.monitoringConf`                 | Use default monitoring.conf                                                       | `true`                                              |
+| `configMaps.useDefaults.outputConf`                     | Use default output.conf                                                           | `true`                                              |
+| `extraConfigMaps`                                       | Add additional Configmap or overwrite disabled default                            | `{}`                                                |
+| `elasticsearch.auth.enabled`                            | Elasticsearch Auth enabled                                                        | `false`                                             |
+| `elasticsearch.auth.user`                               | Elasticsearch Auth User                                                           | `null`                                              |
+| `elasticsearch.auth.password`                           | Elasticsearch Auth Password                                                       | `null`                                              |
+| `elasticsearch.auth.existingSecret.name`                | Name of secret                                                                    | `null`                                              |
+| `elasticsearch.auth.existingSecret.key`                 | Key within secret containing password                                             | `null`                                              |
+| `elasticsearch.setOutputHostEnvVar`                     | Use `elasticsearch.hosts` (Disable this to manually configure hosts)              | `true`                                              |
+| `elasticsearch.hosts`                                   | Elasticsearch Hosts List (host and port)                                          | `["elasticsearch-client:9200"]`                     |
+| `elasticsearch.includeTagKey`                           | Elasticsearch Including of Tag key                                                | `true`                                              |
+| `elasticsearch.logstash.enabled`                        | Elasticsearch Logstash enabled (supersedes indexName)                             | `true`                                              |
+| `elasticsearch.logstash.prefix`                         | Elasticsearch Logstash prefix                                                     | `logstash`                                          |
+| `elasticsearch.logstash.prefixSeparator`                | Elasticsearch Logstash prefix separator                                           | `-`                                                 |
+| `elasticsearch.logstash.dateformat`                     | Elasticsearch Logstash strftime format to generate index target index name        | `%Y.%m.%d`                                          |
+| `elasticsearch.ilm.enabled`                             | Elasticsearch Index Lifecycle Management enabled                                  | `false`                                             |
+| `elasticsearch.ilm.policy_id`                           | Elasticsearch ILM policy ID                                                       | `logstash-policy`                                   |
+| `elasticsearch.ilm.policy`                              | Elasticsearch ILM policy to create                                                | `{}`                                                |
+| `elasticsearch.ilm.policies`                            | Elasticsearch ILM policies to create, map of policy IDs and policies              | `{}`                                                |
+| `elasticsearch.ilm.policy_overwrite`                    | Elastichsarch ILM policy overwrite                                                | `false`                                             |
+| `elasticsearch.template.enabled`                        | Elastichsarch Template enabled                                                    | `false`                                             |
+| `elasticsearch.template.name`                           | Elastichsarch Template Name                                                       | `fluentd-template`                                  |
+| `elasticsearch.template.file`                           | Elasticsearch Template File Name (inside the daemonset)                           | `fluentd-template.json`                             |
+| `elasticsearch.template.content`                        | Elasticsearch Template Content                                                    | _see `values.yaml`_                                 |
+| `elasticsearch.template.overwrite`                      | Elasticsearch Template Overwrite (update even if it already exists)               | `false`                                             |
+| `elasticsearch.template.useLegacy`                      | Use legacy Elasticsearch template                                                 | `true`                                              |
+| `elasticsearch.indexName`                               | Elasticsearch Index Name                                                          | `fluentd`                                           |
+| `elasticsearch.path`                                    | Elasticsearch Path                                                                | `""`                                                |
+| `elasticsearch.scheme`                                  | Elasticsearch scheme setting                                                      | `http`                                              |
+| `elasticsearch.sslVerify`                               | Elasticsearch Auth SSL verify                                                     | `true`                                              |
+| `elasticsearch.sslVersion`                              | Elasticsearch tls version setting                                                 | `TLSv1_2`                                           |
+| `elasticsearch.outputType`                              | Elasticsearch output type                                                         | `elasticsearch`                                     |
+| `elasticsearch.typeName`                                | Elasticsearch type name                                                           | `_doc`                                              |
+| `elasticsearch.logLevel`                                | Elasticsearch global log level                                                    | `info`                                              |
+| `elasticsearch.log400Reason`                            | Elasticsearch Log 400 reason                                                      | `false`                                             |
+| `elasticsearch.reconnectOnError`                        | Elasticsearch Reconnect on error                                                  | `true`                                              |
+| `elasticsearch.reloadOnFailure`                         | Elasticsearch Reload on failure                                                   | `false`                                             |
+| `elasticsearch.reloadConnections`                       | Elasticsearch reload connections                                                  | `false`                                             |
+| `elasticsearch.requestTimeout`                          | Elasticsearch request timeout                                                     | `5s`                                                |
+| `elasticsearch.suppressTypeName`                        | Elasticsearch type name suppression (for ES >= 7)                                 | `false`                                             |
+| `elasticsearch.includeTimestamp`                        | Elasticsearch Include timestamp (param used only if logstash is disabled)         | `false`                                             |
+| `elasticsearch.buffer.enabled`                          | Elasticsearch Buffer enabled                                                      | `true`                                              |
+| `elasticsearch.buffer.chunkKeys`                        | Elasticsearch Buffer comma-separated chunk keys                                   | `""`                                                |
+| `elasticsearch.buffer.type`                             | Elasticsearch Buffer type                                                         | `file`                                              |
+| `elasticsearch.buffer.path`                             | Elasticsearch Buffer path                                                         | `/var/log/fluentd-buffers/kubernetes.system.buffer` |
+| `elasticsearch.buffer.flushMode`                        | Elasticsearch Buffer flush mode                                                   | `interval`                                          |
+| `elasticsearch.buffer.retryType`                        | Elasticsearch Buffer retry type                                                   | `exponential_backoff`                               |
+| `elasticsearch.buffer.flushThreadCount`                 | Elasticsearch Buffer flush thread count                                           | `2`                                                 |
+| `elasticsearch.buffer.flushInterval`                    | Elasticsearch Buffer flush interval                                               | `5s`                                                |
+| `elasticsearch.buffer.retryForever`                     | Elasticsearch Buffer retry forever                                                | `true`                                              |
+| `elasticsearch.buffer.retryMaxInterval`                 | Elasticsearch Buffer retry max interval                                           | `30`                                                |
+| `elasticsearch.buffer.chunkLimitSize`                   | Elasticsearch Buffer chunk limit size                                             | `2M`                                                |
+| `elasticsearch.buffer.totalLimitSize`                   | Elasticsearch Buffer queue limit size                                             | `512M`                                              |
+| `elasticsearch.buffer.overflowAction`                   | Elasticsearch Buffer over flow action                                             | `block`                                             |
+| `env`                                                   | List of env vars that are added to the fluentd pods                               | `{}`                                                |
+| `fluentdArgs`                                           | Fluentd args                                                                      | `--no-supervisor -q`                                |
+| `fluentdLogFormat`                                      | Fluentd output log format in the default system.conf (either "text" or "json")    | `text`                                              |
+| `secret`                                                | List of env vars that are set from secrets and added to the fluentd pods          | `[]`                                                |
+| `extraContainers`                                       | Add sidecar containers to each pod in the daemonset                               | `[]`                                                |
+| `extraInitContainers`                                   | Add init containers to each pod in the daemonset                                  | `[]`                                                |
+| `extraVolumeMounts`                                     | Mount extra volume, required to mount ssl certificates when ES has tls enabled    | `[]`                                                |
+| `extraVolumes`                                          | Extra volume                                                                      | `[]`                                                |
+| `fluentConfDir`                                         | Specify where to mount fluentd location                                           | `/etc/fluent/config.d`                              |
+| `hostLogDir.varLog`                                     | Specify where fluentd can find var log                                            | `/var/log`                                          |
+| `hostLogDir.dockerContainers`                           | Specify where fluentd can find logs for docker container                          | `/var/lib/docker/containers`                        |
+| `hostLogDir.libSystemdDir`                              | Specify where fluentd can find logs for lib Systemd                               | `/usr/lib64`                                        |
+| `image.repository`                                      | Image                                                                             | `quay.io/fluentd_elasticsearch/fluentd`             |
+| `image.tag`                                             | Image tag                                                                         | `v3.3.0`                                            |
+| `image.pullPolicy`                                      | Image pull policy                                                                 | `IfNotPresent`                                      |
+| `image.pullSecrets`                                     | Image pull secrets                                                                | ``                                                  |
+| `livenessProbe.enabled`                                 | Whether to enable livenessProbe                                                   | `true`                                              |
+| `livenessProbe.initialDelaySeconds`                     | livenessProbe initial delay seconds                                               | `600`                                               |
+| `livenessProbe.periodSeconds`                           | livenessProbe period seconds                                                      | `60`                                                |
+| `livenessProbe.kind`                                    | livenessProbe kind                                                                | `Set to a Linux compatible command`                 |
+| `nodeSelector`                                          | Optional daemonset nodeSelector                                                   | `{}`                                                |
+| `podSecurityPolicy.annotations`                         | Specify pod annotations in the pod security policy                                | `{}`                                                |
+| `podSecurityPolicy.enabled`                             | Specify if a pod security policy must be created                                  | `false`                                             |
+| `priorityClassName`                                     | Optional PriorityClass for pods                                                   | `""`                                                |
+| `prometheusRule.enabled`                                | Whether to enable Prometheus prometheusRule                                       | `false`                                             |
+| `prometheusRule.prometheusNamespace`                    | Namespace for prometheusRule                                                      | `monitoring`                                        |
+| `prometheusRule.labels`                                 | Optional labels for prometheusRule                                                | `{}`                                                |
+| `rbac.create`                                           | RBAC                                                                              | `true`                                              |
+| `resources.limits.cpu`                                  | CPU limit                                                                         | `100m`                                              |
+| `resources.limits.memory`                               | Memory limit                                                                      | `500Mi`                                             |
+| `resources.requests.cpu`                                | CPU request                                                                       | `100m`                                              |
+| `resources.requests.memory`                             | Memory request                                                                    | `200Mi`                                             |
+| `service`                                               | Service definition                                                                | `{}`                                                |
+| `service.ports`                                         | List of service ports dict [{name:...}...]                                        | Not Set                                             |
+| `service.ports[].type`                                  | Service type (ClusterIP/NodePort)                                                 | `ClusterIP`                                         |
+| `service.ports[].name`                                  | One of service ports name                                                         | Not Set                                             |
+| `service.ports[].port`                                  | Service port                                                                      | Not Set                                             |
+| `service.ports[].nodePort`                              | NodePort port (when service.type is NodePort)                                     | Not Set                                             |
+| `service.ports[].protocol`                              | Service protocol(optional, can be TCP/UDP)                                        | Not Set                                             |
+| `serviceAccount.create`                                 | Specifies whether a service account should be created.                            | `true`                                              |
+| `serviceAccount.name`                                   | Name of the service account.                                                      | `""`                                                |
+| `serviceAccount.annotations`                            | Specify annotations in the pod service account                                    | `{}`                                                |
+| `serviceMetric.enabled`                                 | Generate the metric service regardless of whether serviceMonitor is enabled.      | `false`                                             |
+| `serviceMonitor.enabled`                                | Whether to enable Prometheus serviceMonitor                                       | `false`                                             |
+| `serviceMonitor.port`                                   | Define on which port the ServiceMonitor should scrape                             | `24231`                                             |
+| `serviceMonitor.interval`                               | Interval at which metrics should be scraped                                       | `10s`                                               |
+| `serviceMonitor.path`                                   | Path for Metrics                                                                  | `/metrics`                                          |
+| `serviceMonitor.labels`                                 | Optional labels for serviceMonitor                                                | `{}`                                                |
+| `serviceMonitor.metricRelabelings`                      | Optional metric relabel configs to apply to samples before ingestion              | `[]`                                                |
+| `serviceMonitor.relabelings`                            | Optional relabel configs to apply to samples before scraping                      | `[]`                                                |
+| `serviceMonitor.jobLabel`                               | PrometheusRule jobLabel. Uses the created metrics service name if not set.        | Not Set                                             |
+| `serviceMonitor.type`                                   | Optional the type of the metrics service                                          | `ClusterIP`                                         |
+| `tolerations`                                           | Optional daemonset tolerations                                                    | `[]`                                                |
+| `updateStrategy`                                        | Optional daemonset update strategy                                                | `type: RollingUpdate`                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -130,14 +130,14 @@ data:
           time_format %Y-%m-%dT%H:%M:%S.%NZ
 {{- if .Values.configMaps.useDefaults.containersKeepTimeKey }}
           keep_time_key true
-{{- end }}          
+{{- end }}
         </pattern>
         <pattern>
           format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
           time_format %Y-%m-%dT%H:%M:%S.%N%:z
 {{- if .Values.configMaps.useDefaults.containersKeepTimeKey }}
           keep_time_key true
-{{- end }}          
+{{- end }}
         </pattern>
       </parse>
     </source>
@@ -169,6 +169,9 @@ data:
     <filter kubernetes.**>
       @id filter_kubernetes_metadata
       @type kubernetes_metadata
+{{- range $key, $value := .Values.configMaps.useDefaults.kubernetesMetadataFilterConfig }}
+      {{ $key }} {{ $value }}
+{{- end }}
     </filter>
 
     # Fixes json fields in Elasticsearch

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -354,6 +354,12 @@ configMaps:
     monitoringConf: true
     outputConf: true
 
+    # kubernetesMetadataFilterConfig lets you set arbitrary
+    # configuration key-value pairs for the kubernetes_metadata
+    # filter. See
+    # https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
+    kubernetesMetadataFilterConfig: {}
+
 # can be used to add new config or overwrite the default configmaps completely after the configmaps default has been disabled above
 extraConfigMaps: {}
   # system.conf: |-


### PR DESCRIPTION
This allows the user to set any configuration they wish for the
`kubernetes_metadata` filter without overriding the entire
`containers.input.conf` configmap. One use case would be to add
specific annotations to the log messages with `annotation_match`.

Signed-off-by: Chris St. Pierre <chris.a.st.pierre@gmail.com>

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/{{ .GitHubOrg }}/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
# Which chart

fluentd-elasticsearch

# What this PR does / why we need it

This lets the user add arbitrary configuration to the `kubernetes_metadata` filter without overriding the entire `containers.input.conf` configmap. Our specific use case is to use `annotation_match` to add certain annotations to the log messages, but I've implemented this as a generic solution so that any additional configuration can be added to that filter.

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] All variables are documented in the charts README