### PR TITLE
Updating fluentd-elasticsearch Helm Chart to support extra k8s Manifest

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 13.2.1
+version: 13.3.0
 appVersion: 3.4.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 13.2.0
+version: 13.2.1
 appVersion: 3.4.0
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -169,6 +169,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `serviceMonitor.type`                                   | Optional the type of the metrics service                                          | `ClusterIP`                                         |
 | `tolerations`                                           | Optional daemonset tolerations                                                    | `[]`                                                |
 | `updateStrategy`                                        | Optional daemonset update strategy                                                | `type: RollingUpdate`                               |
+| `extraObjects`                                          | Array of extra K8s manifests to deploy                                            | `[]`                                                |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/fluentd-elasticsearch/templates/extraManifests.yaml
+++ b/charts/fluentd-elasticsearch/templates/extraManifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }} 

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -416,3 +416,29 @@ extraInitContainers: []
 # - name: do-something
 #   image: busybox
 #   command: ['do', 'something']
+
+# -- Array of extra K8s manifests to deploy
+extraObjects: []
+  # - apiVersion: secrets-store.csi.x-k8s.io/v1
+  #   kind: SecretProviderClass
+  #   metadata:
+  #     name: my-secrets-store
+  #   spec:
+  #     provider: aws
+  #     parameters:
+  #       objects: |
+  #         - objectName: "openid-secret"
+  #           objectType: "secretsmanager"
+  #           jmesPath:
+  #               - path: "client_id"
+  #                 objectAlias: "client_id"
+  #               - path: "client_secret"
+  #                 objectAlias: "client_secret"
+  #     secretObjects:
+  #     - data:
+  #       - key: client_id
+  #         objectName: client_id
+  #       - key: client_secret
+  #         objectName: client_secret
+  #       secretName: openid-secrets-store
+  #       type: Opaque


### PR DESCRIPTION

# Which chart
fluentd-elasticsearch

# What this PR does / why we need it
Providing a new addition, like many other opensource helm charts (e.g. grafana, prometheus, argo-cd), to support extra k8s manifests using the values files.
This allows the end user to add any additional files needed to support their helm deployment. A nice use case now a days is to mount secrets on the fly by leveraging the Secrets Store CSI Driver.


# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] All variables are documented in the charts README