### PR TITLE
Image version 4.2.3 does not exist

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fluentd-elasticsearch
 version: 13.7.1
-appVersion: v4.2.3
+appVersion: v4.2.2
 type: application
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output


### PR DESCRIPTION
Tag 4.2.3 does not exist.

See https://quay.io/repository/fluentd_elasticsearch/fluentd?tab=tags&tag=v4.2.3

This PR reverts to 4.2.2
