### PR TITLE
feat(fluentd): Make buffer path configurable in livenessProbe

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fluentd-elasticsearch
-version: 13.7.1
+version: 13.8.0
 appVersion: v4.2.3
 type: application
 home: https://www.fluentd.org/

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -146,6 +146,7 @@ env: {}
   # OUTPUT_USER: my_user
   # LIVENESS_THRESHOLD_SECONDS: 300
   # STUCK_THRESHOLD_SECONDS: 900
+  # BUFFER_PATH: /var/log/fluentd-buffers/kubernetes.system.buffer
 
 # If you want to add custom environment variables from secrets, use the secret list
 secret: []
@@ -198,22 +199,23 @@ livenessProbe:
       - >
         LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
         STUCK_THRESHOLD_SECONDS=${STUCK_THRESHOLD_SECONDS:-900};
-        if [ ! -e /var/log/fluentd-buffers ];
+        BUFFER_PATH=${BUFFER_PATH:-/var/log/fluentd-buffers/kubernetes.system.buffer}
+        if [ ! -e ${BUFFER_PATH} ];
         then
-          echo "Expected directory /var/log/fluentd-buffers does not exist. This is likely a configuration issue.";
+          echo "Expected file ${BUFFER_PATH} does not exist. This is likely a configuration issue.";
           exit 1;
         fi;
         touch -d "${STUCK_THRESHOLD_SECONDS} seconds ago" /tmp/marker-stuck;
-        if [ -n "$(find /var/log/fluentd-buffers -mindepth 1 -type d ! -newer /tmp/marker-stuck -print -quit)" ];
+        if [ -n "$(find ${BUFFER_PATH} -mindepth 1 -type d ! -newer /tmp/marker-stuck -print -quit)" ];
         then
-          echo "Elasticsearch buffers found stuck longer than $STUCK_THRESHOLD_SECONDS seconds. Clearing buffers."
-          rm -rf /var/log/fluentd-buffers;
+          echo "Elasticsearch buffer found stuck longer than $STUCK_THRESHOLD_SECONDS seconds. Clearing buffer."
+          rm -rf ${BUFFER_PATH};
           exit 1;
         fi;
         touch -d "${LIVENESS_THRESHOLD_SECONDS} seconds ago" /tmp/marker-liveness;
-        if [ -n "$(find /var/log/fluentd-buffers -mindepth 1 -type d ! -newer /tmp/marker-liveness -print -quit)" ];
+        if [ -n "$(find ${BUFFER_PATH} -mindepth 1 -type d ! -newer /tmp/marker-liveness -print -quit)" ];
         then
-          echo "Elasticsearch buffers found stuck longer than $LIVENESS_THRESHOLD_SECONDS seconds."
+          echo "Elasticsearch buffer found stuck longer than $LIVENESS_THRESHOLD_SECONDS seconds."
           exit 1;
         fi;
 


### PR DESCRIPTION
Signed-off-by: Kevin Huang <git@kevin.huang.to>

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/{{ .GitHubOrg }}/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
# Which chart

fluentd-elastricsearch

# What this PR does / why we need it

This PR makes the buffer path configurable in livenessProbe. 

We have the usecase where several fluentd each have their own buffers in /var/log/fluentd-buffers. When one fluentd crashes, we do not want it to `rm -rf /var/log/fluentd-buffers`, it would also delete the buffers of the other fluentd.

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/kokuwaio/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
